### PR TITLE
PCCIS-43 | added navigation to group

### DIFF
--- a/src/app/app-top-nav/app-top-nav.component.html
+++ b/src/app/app-top-nav/app-top-nav.component.html
@@ -13,6 +13,7 @@
       <a href = 'https://www.changeissimple.org/about' target="_blank" class="white-text">About </a>
       <a href = 'http://www.changeissimple.org' target="_blank" class="white-text">FAQ </a>
       <a *ngIf= "!hideRightMenu || isOnLevelPage" routerLink="/level" class="white-text">Levels </a>
+      <a *ngIf= "!hideRightMenu" routerLink = "/groups" class="white-text">Groups </a>
       <a *ngIf= "!hideRightMenu" routerLink = "/contactus" class="white-text">Contact </a>
       <a *ngIf= "isAdmin" routerLink="/adminaccesslanding" class="white-text">Admin Portal</a>
       <a *ngIf= "!hideRightMenu" routerLink="/userprofile" class="white-text">My Profile</a>


### PR DESCRIPTION
There was no navigation to group for the user, the only link was on Home page and user would have to go back to see it. User is now able to click and navigate to groups from nav bar